### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: test
 on:
   workflow_dispatch:
+permissions: {}
 jobs:
   tweet:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/legnoh/x-bot/security/code-scanning/5](https://github.com/legnoh/x-bot/security/code-scanning/5)

To remedy the problem, add a `permissions` block to the workflow file to ensure the GITHUB_TOKEN for this workflow has only the minimum necessary permission. Since the tweet-posting step does not require any GitHub API permissions, we can set `permissions: {} ` at the top level for the strictest setting, or `permissions: read-all`, or even more minimally, `permissions: {}` (which disables all permissions). To future-proof, the most secure approach is to explicitly set `permissions: {}` at the workflow level, just below the `name:` and `on:` sections, so that it applies to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
