### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hanakin.yml
+++ b/.github/workflows/hanakin.yml
@@ -1,4 +1,5 @@
 name: 花金だーワッショーイ！テンションAGEAGEマック
+permissions: {}
 on:
   schedule:
     - cron: '0 9 * * 5' # Friday 18:00 (JST)


### PR DESCRIPTION
Potential fix for [https://github.com/legnoh/x-bot/security/code-scanning/4](https://github.com/legnoh/x-bot/security/code-scanning/4)

The best fix is to add an explicit `permissions` block to the workflow. Since the job does not use the `GITHUB_TOKEN` for any actions and does not require any repository or pull request access, the most restrictive setting should be used: `permissions: {}` at the workflow root. This blocks all default permissions for the workflow and jobs unless overridden. You should add this block after the `name:` line (before `on:`), or after `on:` for a root-level setting.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
