### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/edm.yml
+++ b/.github/workflows/edm.yml
@@ -2,6 +2,7 @@ name: 人生どうでもEDM
 on:
   schedule:
     - cron: '0 5 * * 3' # Wednesday 14:00 (JST)
+permissions: {}  # Disable all GITHUB_TOKEN permissions; principle of least privilege
 jobs:
   tweet:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/legnoh/x-bot/security/code-scanning/2](https://github.com/legnoh/x-bot/security/code-scanning/2)

To fix the issue, explicitly add a `permissions` block to the workflow or the relevant job(s). Since this workflow appears to only use secrets to post a tweet and does not interact with the repository or use GITHUB_TOKEN for any API calls, the most restrictive and recommended setting is to disable all GITHUB_TOKEN scopes by adding:

```yaml
permissions: {}
```

This can be placed at the root level (above `jobs:`) to apply to all jobs in the workflow, or for future granularity, you could set it per job. The best approach here is to add it after the `name:` and `on:` blocks, before `jobs:`.

No additional imports, methods, or definitions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
