### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/kujisaki.yml
+++ b/.github/workflows/kujisaki.yml
@@ -1,4 +1,5 @@
 name: 久慈咲さんのファンやめます
+permissions: {}
 on:
   schedule:
     - cron: '0 18 * * 6' # Sunday 03:00 (JST)


### PR DESCRIPTION
Potential fix for [https://github.com/legnoh/x-bot/security/code-scanning/1](https://github.com/legnoh/x-bot/security/code-scanning/1)

To fix the problem, add a `permissions:` block to the workflow, restricting access to the repository's resources to the minimal level required. Since the workflow only posts a tweet using secrets and does not interact with the repository's contents, setting `permissions: {}` (i.e., disabling all default permissions) is safest and recommended by GitHub for jobs that don't touch repository data.  

- The block should be added at the top level, after the `name:` and before or after the `on:` key.  
- No additional imports, methods, or variables are required.  
- The addition does not alter the workflow’s functionality, since the action only relies on secrets and does not use the GITHUB_TOKEN for any repo operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
